### PR TITLE
Added new parameters and adjusted number of processes based on number of cores

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Uninitialized environment" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/s3tk.iml" filepath="$PROJECT_DIR$/.idea/s3tk.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/s3tk.iml
+++ b/.idea/s3tk.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="Unittests" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,379 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="1baa75a8-5a4e-4c83-a1e5-c1684a3b49e4" name="Default" comment="">
+      <change afterPath="$PROJECT_DIR$/.idea/misc.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/modules.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/s3tk.iml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/vcs.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/s3tk/__init__.py" beforeDir="false" afterPath="$PROJECT_DIR$/s3tk/__init__.py" afterDir="false" />
+    </list>
+    <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
+    <option name="TRACKING_ENABLED" value="true" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="FileEditorManager">
+    <leaf SIDE_TABS_SIZE_LIMIT_KEY="300">
+      <file leaf-file-name="__init__.py" pinned="false" current-in-tab="true">
+        <entry file="file://$PROJECT_DIR$/s3tk/__init__.py">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="279">
+              <caret line="174" column="15" selection-start-line="174" selection-start-column="4" selection-end-line="174" selection-end-column="15" />
+              <folding>
+                <element signature="e#0#10#0" expanded="true" />
+              </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="checks.py" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/s3tk/checks.py">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="285">
+              <caret line="20" column="8" selection-start-line="20" selection-start-column="8" selection-end-line="20" selection-end-column="8" />
+              <folding>
+                <element signature="e#0#11#0" expanded="true" />
+              </folding>
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="s3tk" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/bin/s3tk">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="90">
+              <caret line="8" column="13" selection-start-line="8" selection-start-column="13" selection-end-line="8" selection-end-column="13" />
+            </state>
+          </provider>
+        </entry>
+      </file>
+    </leaf>
+  </component>
+  <component name="FindInProjectRecents">
+    <findStrings>
+      <find>summarize</find>
+      <find>Bucket</find>
+      <find>'error</find>
+      <find>Total</find>
+      <find>AccessDeniend</find>
+      <find>^^</find>
+      <find>abort</find>
+      <find>public</find>
+      <find>scan_object</find>
+    </findStrings>
+    <replaceStrings>
+      <replace />
+    </replaceStrings>
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="IdeDocumentHistory">
+    <option name="CHANGED_PATHS">
+      <list>
+        <option value="$PROJECT_DIR$/bin/s3tk" />
+        <option value="$PROJECT_DIR$/s3tk/__init__.py" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectFrameBounds" extendedState="6">
+    <option name="x" value="454" />
+    <option name="y" value="1436" />
+    <option name="width" value="1855" />
+    <option name="height" value="1084" />
+  </component>
+  <component name="ProjectView">
+    <navigator proportions="" version="1">
+      <foldersAlwaysOnTop value="true" />
+    </navigator>
+    <panes>
+      <pane id="Scope" />
+      <pane id="ProjectPane">
+        <subPane>
+          <expand>
+            <path>
+              <item name="s3tk" type="b2602c69:ProjectViewProjectNode" />
+              <item name="s3tk" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="s3tk" type="b2602c69:ProjectViewProjectNode" />
+              <item name="s3tk" type="462c0819:PsiDirectoryNode" />
+              <item name="bin" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="s3tk" type="b2602c69:ProjectViewProjectNode" />
+              <item name="s3tk" type="462c0819:PsiDirectoryNode" />
+              <item name="s3tk" type="462c0819:PsiDirectoryNode" />
+            </path>
+            <path>
+              <item name="s3tk" type="b2602c69:ProjectViewProjectNode" />
+              <item name="s3tk" type="462c0819:PsiDirectoryNode" />
+              <item name="s3tk.egg-info" type="462c0819:PsiDirectoryNode" />
+            </path>
+          </expand>
+          <select />
+        </subPane>
+      </pane>
+    </panes>
+  </component>
+  <component name="PropertiesComponent">
+    <property name="last_opened_file_path" value="$PROJECT_DIR$/bin/s3tk" />
+  </component>
+  <component name="RunDashboard">
+    <option name="ruleStates">
+      <list>
+        <RuleState>
+          <option name="name" value="ConfigurationTypeDashboardGroupingRule" />
+        </RuleState>
+        <RuleState>
+          <option name="name" value="StatusDashboardGroupingRule" />
+        </RuleState>
+      </list>
+    </option>
+  </component>
+  <component name="RunManager" selected="Python.Unnamed">
+    <configuration name="Unnamed" type="PythonConfigurationType" factoryName="Python">
+      <module name="s3tk" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <envs>
+        <env name="PYTHONUNBUFFERED" value="1" />
+      </envs>
+      <option name="SDK_HOME" value="$USER_HOME$/PycharmProjects/trusted-advisor-api/venv/bin/python" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/bin" />
+      <option name="IS_MODULE_SDK" value="false" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/bin/s3tk" />
+      <option name="PARAMETERS" value="scan-object-acl" />
+      <option name="SHOW_COMMAND_LINE" value="false" />
+      <option name="EMULATE_TERMINAL" value="false" />
+      <option name="MODULE_MODE" value="false" />
+    </configuration>
+    <configuration name="__init__" type="PythonConfigurationType" factoryName="Python" temporary="true">
+      <module name="s3tk" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <envs>
+        <env name="PYTHONUNBUFFERED" value="1" />
+      </envs>
+      <option name="SDK_HOME" value="" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/s3tk" />
+      <option name="IS_MODULE_SDK" value="true" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/s3tk/__init__.py" />
+      <option name="PARAMETERS" value="" />
+      <option name="SHOW_COMMAND_LINE" value="false" />
+      <option name="EMULATE_TERMINAL" value="false" />
+      <option name="MODULE_MODE" value="false" />
+    </configuration>
+    <list>
+      <item itemvalue="Python.Unnamed" />
+      <item itemvalue="Python.__init__" />
+    </list>
+    <recent_temporary>
+      <list>
+        <item itemvalue="Python.__init__" />
+      </list>
+    </recent_temporary>
+  </component>
+  <component name="SvnConfiguration">
+    <configuration />
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="1baa75a8-5a4e-4c83-a1e5-c1684a3b49e4" name="Default" comment="" />
+      <created>1525441118784</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1525441118784</updated>
+    </task>
+    <task id="LOCAL-00001" summary="Adjusted input parameters">
+      <created>1525442386301</created>
+      <option name="number" value="00001" />
+      <option name="presentableId" value="LOCAL-00001" />
+      <option name="project" value="LOCAL" />
+      <updated>1525442386301</updated>
+    </task>
+    <task id="LOCAL-00002" summary="Adjusted input parameters">
+      <created>1525444142005</created>
+      <option name="number" value="00002" />
+      <option name="presentableId" value="LOCAL-00002" />
+      <option name="project" value="LOCAL" />
+      <updated>1525444142005</updated>
+    </task>
+    <task id="LOCAL-00003" summary="Do not exit or ClientError (i.e Access Denied). Neede for a function of --scan-all (Scan all Buckets)">
+      <created>1525678130858</created>
+      <option name="number" value="00003" />
+      <option name="presentableId" value="LOCAL-00003" />
+      <option name="project" value="LOCAL" />
+      <updated>1525678130858</updated>
+    </task>
+    <task id="LOCAL-00004" summary="Do not exit or ClientError (i.e Access Denied). Neede for a function of --scan-all (Scan all Buckets)">
+      <created>1525764160934</created>
+      <option name="number" value="00004" />
+      <option name="presentableId" value="LOCAL-00004" />
+      <option name="project" value="LOCAL" />
+      <updated>1525764160934</updated>
+    </task>
+    <task id="LOCAL-00005" summary="Do not exit or ClientError (i.e Access Denied). Neede for a function of --scan-all (Scan all Buckets)">
+      <created>1525856104324</created>
+      <option name="number" value="00005" />
+      <option name="presentableId" value="LOCAL-00005" />
+      <option name="project" value="LOCAL" />
+      <updated>1525856104324</updated>
+    </task>
+    <task id="LOCAL-00006" summary="Do not exit or ClientError (i.e Access Denied). Neede for a function of --scan-all (Scan all Buckets)">
+      <created>1525856160803</created>
+      <option name="number" value="00006" />
+      <option name="presentableId" value="LOCAL-00006" />
+      <option name="project" value="LOCAL" />
+      <updated>1525856160803</updated>
+    </task>
+    <option name="localTasksCounter" value="7" />
+    <servers />
+  </component>
+  <component name="ToolWindowManager">
+    <frame x="390" y="1436" width="1855" height="1084" extended-state="6" />
+    <editor active="true" />
+    <layout>
+      <window_info active="true" content_ui="combo" id="Project" order="0" visible="true" weight="0.25" />
+      <window_info anchor="bottom" id="TODO" order="6" />
+      <window_info anchor="bottom" id="Event Log" order="7" side_tool="true" />
+      <window_info anchor="bottom" id="Run" order="2" weight="0.32948583" />
+      <window_info anchor="bottom" id="Version Control" order="7" />
+      <window_info anchor="bottom" id="Python Console" order="7" />
+      <window_info id="Structure" order="1" side_tool="true" weight="0.25" />
+      <window_info anchor="bottom" id="Terminal" order="7" />
+      <window_info anchor="bottom" id="Debug" order="3" weight="0.39979014" />
+      <window_info id="Favorites" order="2" side_tool="true" />
+      <window_info anchor="right" content_ui="combo" id="Hierarchy" order="2" weight="0.25" />
+      <window_info anchor="right" id="Commander" internal_type="SLIDING" order="0" type="SLIDING" weight="0.4" />
+      <window_info anchor="right" id="Ant Build" order="1" weight="0.25" />
+      <window_info anchor="bottom" id="Message" order="0" />
+      <window_info anchor="bottom" id="Inspection" order="5" weight="0.4" />
+      <window_info anchor="bottom" id="Cvs" order="4" weight="0.25" />
+      <window_info anchor="bottom" id="Find" order="1" />
+    </layout>
+  </component>
+  <component name="VcsContentAnnotationSettings">
+    <option name="myLimit" value="2678400000" />
+  </component>
+  <component name="VcsManagerConfiguration">
+    <MESSAGE value="Adjusted input parameters" />
+    <MESSAGE value="Do not exit or ClientError (i.e Access Denied). Neede for a function of --scan-all (Scan all Buckets)" />
+    <option name="LAST_COMMIT_MESSAGE" value="Do not exit or ClientError (i.e Access Denied). Neede for a function of --scan-all (Scan all Buckets)" />
+  </component>
+  <component name="XDebuggerManager">
+    <breakpoint-manager>
+      <option name="time" value="1" />
+    </breakpoint-manager>
+  </component>
+  <component name="editorHistoryManager">
+    <entry file="file://$PROJECT_DIR$/s3tk/__init__.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="750">
+          <caret line="61" column="18" selection-start-line="61" selection-start-column="18" selection-end-line="61" selection-end-column="18" />
+          <folding>
+            <element signature="e#0#10#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/s3tk/checks.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="300">
+          <caret line="20" column="8" selection-start-line="20" selection-start-column="8" selection-end-line="20" selection-end-column="8" />
+          <folding>
+            <element signature="e#0#11#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/bin/s3tk">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="120">
+          <caret line="8" column="13" lean-forward="true" selection-start-line="8" selection-start-column="13" selection-end-line="8" selection-end-column="13" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/s3tk/__init__.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="750">
+          <caret line="61" column="18" selection-start-line="61" selection-start-column="18" selection-end-line="61" selection-end-column="18" />
+          <folding>
+            <element signature="e#0#10#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/s3tk/checks.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="285">
+          <caret line="20" column="8" selection-start-line="20" selection-start-column="8" selection-end-line="20" selection-end-column="8" />
+          <folding>
+            <element signature="e#0#11#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/bin/s3tk">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="90">
+          <caret line="8" column="22" selection-start-line="8" selection-start-column="22" selection-end-line="8" selection-end-column="22" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/s3tk/__init__.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="3600">
+          <caret line="240" selection-start-line="240" selection-end-line="240" />
+          <folding>
+            <element signature="e#0#10#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/s3tk/__init__.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state>
+          <folding>
+            <element signature="e#0#10#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/s3tk/checks.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="285">
+          <caret line="20" column="8" selection-start-line="20" selection-start-column="8" selection-end-line="20" selection-end-column="8" />
+          <folding>
+            <element signature="e#0#11#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/bin/s3tk">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="90">
+          <caret line="8" column="13" selection-start-line="8" selection-start-column="13" selection-end-line="8" selection-end-column="13" />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/s3tk/__init__.py">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="279">
+          <caret line="174" column="15" selection-start-line="174" selection-start-column="4" selection-end-line="174" selection-end-column="15" />
+          <folding>
+            <element signature="e#0#10#0" expanded="true" />
+          </folding>
+        </state>
+      </provider>
+    </entry>
+  </component>
+</project>

--- a/bin/s3tk
+++ b/bin/s3tk
@@ -7,5 +7,6 @@ try:
     s3tk.cli()
 except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
     s3tk.abort(str(e))
+    pass
 except KeyboardInterrupt:
     sys.exit(1)

--- a/s3tk/__init__.py
+++ b/s3tk/__init__.py
@@ -515,7 +515,7 @@ def scan_object_acl(bucket=None, only=None, _except=None, scan_all=None):
        
 def print_help_msg(command):
     with click.Context(command) as ctx:
-        ctx.info_name = "s3tk scan-object-acl"
+        ctx.info_name = "s3tk " + ctx.command.name
         ctx.parent = None
         click.echo(command.get_help(ctx))
 

--- a/s3tk/__init__.py
+++ b/s3tk/__init__.py
@@ -180,6 +180,7 @@ def scan_object(bucket_name, key):
         return 'error'
     try:
         mode = determine_mode(obj.Acl())
+
         if type == "public":
 
             if (mode == 'public-read') or (mode == 'public-read-write'):

--- a/s3tk/__init__.py
+++ b/s3tk/__init__.py
@@ -54,7 +54,7 @@ def notice(message):
 
 def abort(message):
     puts(colored.red(message))
-    sys.exit(1)
+    #sys.exit(1)
 
 
 def unicode_key(key):

--- a/s3tk/__init__.py
+++ b/s3tk/__init__.py
@@ -255,14 +255,14 @@ def parallelize(bucket, only, _except, fn, args=(), versions=False):
     if versions:
         object_versions = bucket.object_versions.filter(Prefix=prefix) if prefix else bucket.object_versions.all()
         # delete markers have no size
-        return Parallel(n_jobs=24)(delayed(fn)(bucket.name, ov.object_key, ov.id, *args) for ov in object_versions if object_matches(ov.object_key, only, _except) and not ov.is_latest and ov.size is not None)
+        return Parallel(n_jobs=-1)(delayed(fn)(bucket.name, ov.object_key, ov.id, *args) for ov in object_versions if object_matches(ov.object_key, only, _except) and not ov.is_latest and ov.size is not None)
     else:
         objects = bucket.objects.filter(Prefix=prefix) if prefix else bucket.objects.all()
 
         if only and not '*' in only:
             objects = [s3.Object(bucket, only)]
 
-        return Parallel(n_jobs=24)(delayed(fn)(bucket.name, os.key, *args) for os in objects if object_matches(os.key, only, _except))
+        return Parallel(n_jobs=-1)(delayed(fn)(bucket.name, os.key, *args) for os in objects if object_matches(os.key, only, _except))
 
 
 def public_statement(bucket):

--- a/s3tk/__init__.py
+++ b/s3tk/__init__.py
@@ -184,7 +184,7 @@ def scan_object(bucket_name, key):
 
             if (mode == 'public-read') or (mode == 'public-read-write'):
                 puts(str_key + ' ' + colored.red(mode))
-        else:
+            else:
                 puts(str_key + ' ' + colored.red(mode))
 
 

--- a/s3tk/__init__.py
+++ b/s3tk/__init__.py
@@ -490,7 +490,7 @@ def encrypt(bucket, only=None, _except=None, dry_run=False, kms_key_id=None, cus
 
 
 @cli.command(name='scan-object-acl')
-@click.argument('bucket', default="all")
+@click.argument('bucket', required=False)
 @click.option('--only', help='Only certain objects')
 @click.option('--except', '_except', help='Except certain objects')
 @click.option('--scan-all', is_flag=True, help='All buckets')
@@ -506,11 +506,19 @@ def scan_object_acl(bucket=None, only=None, _except=None, scan_all=None):
             puts(bucket.name)
             total = total + summarize(parallelize(bucket.name, only, _except, scan_object), bucket.name)
         puts("Total: "+str(total))
-    elif only or _except or bucket!="all":
+    elif only or _except or bucket is not None:
         total = total + summarize(parallelize(bucket, only, _except, scan_object), bucket)   
         puts("Total: "+str(total))
     else:
-        puts("Error: Missing argument [OPTIONS] BUCKET")
+        print_help_msg(scan_object_acl)
+     
+       
+def print_help_msg(command):
+    with click.Context(command) as ctx:
+        ctx.info_name = "s3tk scan-object-acl"
+        ctx.parent = None
+        click.echo(command.get_help(ctx))
+
         
 
 @cli.command(name='reset-object-acl')

--- a/s3tk/__init__.py
+++ b/s3tk/__init__.py
@@ -174,13 +174,10 @@ def scan_object(bucket_name, key):
     try:
         mode = determine_mode(obj.Acl())
         
-	'''
-        if mode == 'private':
-            puts(str_key + ' ' + colored.green(mode))
-        else:
-            puts(str_key + ' ' + colored.yellow(mode))
-        '''
-
+	
+        if (mode == 'public-read') or (mode == 'public-read-write'):
+            puts(str_key + ' ' + colored.red(mode))
+        
         return mode
     except (botocore.exceptions.ClientError, botocore.exceptions.NoCredentialsError) as e:
         puts(str_key + ' ' + colored.red(str(e)))
@@ -369,7 +366,7 @@ def summarize(values, bucket):
     
     puts()
     for k, v in summary.most_common():
-        if k == "public-read":
+        if (k == "public-read") or (k == "public-write"):
             puts("Bucket:" + colored.red(bucket))
             puts(k + ': ' + str(v))
 

--- a/s3tk/__init__.py
+++ b/s3tk/__init__.py
@@ -65,11 +65,11 @@ def perform(check):
 
     with indent(2):
         if check.status == 'passed':
-            puts(colored.green('✔ ' + check.name + ' ' + check.pass_message))
+            puts(colored.green(check.name + ' ' + check.pass_message))
         elif check.status == 'failed':
-            puts(colored.red('✘ ' + check.name + ' ' + check.fail_message))
+            puts(colored.red(check.name + ' ' + check.fail_message))
         else:
-            puts(colored.red('✘ ' + check.name + ' access denied'))
+            puts(colored.red(check.name + ' access denied'))
 
     return check
 
@@ -171,14 +171,15 @@ def determine_mode(acl):
 def scan_object(bucket_name, key):
     obj = s3.Object(bucket_name, key)
     str_key = unicode_key(key)
-
     try:
         mode = determine_mode(obj.Acl())
-
+        
+	'''
         if mode == 'private':
             puts(str_key + ' ' + colored.green(mode))
         else:
             puts(str_key + ' ' + colored.yellow(mode))
+        '''
 
         return mode
     except (botocore.exceptions.ClientError, botocore.exceptions.NoCredentialsError) as e:
@@ -363,13 +364,14 @@ def print_policy(policy):
             puts(colored.yellow("None"))
 
 
-def summarize(values):
+def summarize(values, bucket):
     summary = Counter(values)
-
+    
     puts()
-    puts("Summary")
     for k, v in summary.most_common():
-        puts(k + ': ' + str(v))
+        if k == "public-read":
+            puts("Bucket:" + colored.red(bucket))
+            puts(k + ': ' + str(v))
 
 
 @click.group()
@@ -486,7 +488,7 @@ def encrypt(bucket, only=None, _except=None, dry_run=False, kms_key_id=None, cus
 @click.option('--only', help='Only certain objects')
 @click.option('--except', '_except', help='Except certain objects')
 def scan_object_acl(bucket, only=None, _except=None):
-    summarize(parallelize(bucket, only, _except, scan_object))
+    summarize(parallelize(bucket, only, _except, scan_object), bucket)
 
 
 @cli.command(name='reset-object-acl')


### PR DESCRIPTION
You can now run 

s3tk scan-object-acl --scan-all

to scan all the bucket for open rights.

Also combine --also-private to show custom and private rights.

I.e



Usage: s3tk scan-object-acl [OPTIONS] [BUCKET]

Options:
  --only TEXT     Only certain objects
  --except TEXT   Except certain objects
  --scan-all      Scan and show all public buckets
  --also-private  Also private
  --help          Show this message and exit.


Also shows at the end the totals for right types and for items

